### PR TITLE
Extra/Restored Textstyle

### DIFF
--- a/scripts/config.js
+++ b/scripts/config.js
@@ -645,8 +645,10 @@ Hooks.on("renderDrawingConfig", (app, root, data) => {
         <div class="form-group">
             <label>Drop Shadow Alpha</label>
             <div class="form-fields">
-                <input type="range" name="flags.${MODULE_ID}.textStyle.dropShadowAlpha" min="0" max="1" step="0.1" value="${ts.dropShadowAlpha ?? "1"}">
-                <span class="range-value">${ts.dropShadowAlpha ?? "1"}</span>
+                <range-picker name="flags.${MODULE_ID}.textStyle.dropShadowAlpha" value="${ts.dropShadowAlpha ?? "1"}" min="0" max="1" step="0.1">
+                    <input type="range" min="0" max="1" step="0.1" style="">
+                    <input type="number" min="0" max="1" step="0.1"}">
+                </range-picker>
             </div>
         </div>
         <div class="form-group">

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -470,6 +470,10 @@ Hooks.on("renderDrawingConfig", (app, root, data) => {
             <input type="number" name="flags.${MODULE_ID}.textStyle.letterSpacing" min="0" step="0.1" placeholder="0" value="${ts.letterSpacing ?? "0"}">
         </div>
         <div class="form-group">
+            <label>Line Height <span class="units">(Pixels)</span></label>
+            <input type="number" name="flags.${MODULE_ID}.textStyle.lineHeight" min="0" step="0.1" placeholder="normal" value="${ts.lineHeight ?? "normal"}">
+        </div> 
+        <div class="form-group">
             <label>Word Wrap Width <span class="units">(Pixels or %)</span></label>
             <input type="text" name="flags.${MODULE_ID}.textStyle.wordWrapWidth" title="Pixels (px) or Percent (%)" pattern="\\s*(\\d*\\.?\\d+)\\s*(px|%)?\\s*" placeholder="100%" value="${stringifyValue(ts.wordWrapWidth) ?? "100%"}">
         </div>

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -611,6 +611,15 @@ Hooks.on("renderDrawingConfig", (app, root, data) => {
             <input type="number" name="flags.${MODULE_ID}.textStyle.strokeThickness" min="0" step="0.1" placeholder="Default" value="${ts.strokeThickness ?? ""}">
         </div>
         <div class="form-group">
+            <label>Stroke Opacity</label>
+            <div class="form-fields">
+                <range-picker name="flags.${MODULE_ID}.textStyle.strokeOpacity" value="${ts.strokeOpacity ?? "1"}" min="0" max="1" step="0.1">
+                    <input type="range" min="0" max="1" step="0.1" style="">
+                    <input type="number" min="0" max="1" step="0.1"}">
+                </range-picker>
+            </div>
+        </div>
+        <div class="form-group">
             <label>Drop Shadow</label>
             <input type="checkbox" name="flags.${MODULE_ID}.textStyle.dropShadow" ${(ts.dropShadow ?? true) ? "checked" : ""}>
         </div>

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -602,8 +602,10 @@ Hooks.on("renderDrawingConfig", (app, root, data) => {
         <div class="form-group">
             <label>Stroke Color</label>
             <div class="form-fields">
-                <input class="color" type="text" name="flags.${MODULE_ID}.textStyle.stroke" placeholder="" value="${ts.stroke || ""}">
-                <input type="color" value="${ts.stroke || "#000000"}" data-edit="flags.${MODULE_ID}.textStyle.stroke">
+                <color-picker name="flags.${MODULE_ID}.textStyle.stroke" placeholder="" value="${ts.stroke || ""}">
+                    <input type="text" placeholder="">
+                    <input type="color" style="">
+                </color-picker>
             </div>
         </div>
         <div class="form-group">
@@ -638,8 +640,10 @@ Hooks.on("renderDrawingConfig", (app, root, data) => {
         <div class="form-group">
             <label>Drop Shadow Color</label>
             <div class="form-fields">
-                <input class="color" type="text" name="flags.${MODULE_ID}.textStyle.dropShadowColor" placeholder="#000000" value="${ts.dropShadowColor || "#000000"}">
-                <input type="color" value="${ts.dropShadowColor || "#000000"}" data-edit="flags.${MODULE_ID}.textStyle.dropShadowColor">
+                <color-picker name="flags.${MODULE_ID}.textStyle.dropShadowColor" placeholder="#000000" value="${ts.dropShadowColor || "#000000"}">
+                    <input type="text" placeholder="#000000">
+                    <input type="color" style="">
+                </color-picker>
             </div>
         </div>
         <div class="form-group">

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -231,16 +231,16 @@ Hooks.on("renderDrawingConfig", (app, root, data) => {
             /* Target the actual form content containers */
             .app.drawing-config .sheet-body,
             .app.drawing-config .form-body,
-            .app.drawing-config .window-content,
+            .app.drawing-config .tab,
             .app.sheet.drawing-config .sheet-body,
             .app.sheet.drawing-config .form-body,
-            .app.sheet.drawing-config .window-content,
+            .app.sheet.drawing-config .tab,
             .app.${MODULE_ID}-scrollable-config .sheet-body,
             .app.${MODULE_ID}-scrollable-config .form-body,
-            .app.${MODULE_ID}-scrollable-config .window-content,
+            .app.${MODULE_ID}-scrollable-config .tab,
             [data-advanced-drawing-tools-scrollable="true"] .sheet-body,
             [data-advanced-drawing-tools-scrollable="true"] .form-body,
-            [data-advanced-drawing-tools-scrollable="true"] .window-content {
+            [data-advanced-drawing-tools-scrollable="true"] .tab {
                 max-height: ${Math.min(window.innerHeight * 0.8, 650)}px;
                 overflow-y: auto;
                 overflow-x: hidden;
@@ -250,51 +250,51 @@ Hooks.on("renderDrawingConfig", (app, root, data) => {
             /* Scrollbar styling for all targeted containers */
             .app.drawing-config .sheet-body::-webkit-scrollbar,
             .app.drawing-config .form-body::-webkit-scrollbar,
-            .app.drawing-config .window-content::-webkit-scrollbar,
+            .app.drawing-config .tab::-webkit-scrollbar,
             .app.sheet.drawing-config .sheet-body::-webkit-scrollbar,
             .app.sheet.drawing-config .form-body::-webkit-scrollbar,
-            .app.sheet.drawing-config .window-content::-webkit-scrollbar,
+            .app.sheet.drawing-config .tab::-webkit-scrollbar,
             .app.${MODULE_ID}-scrollable-config .sheet-body::-webkit-scrollbar,
             .app.${MODULE_ID}-scrollable-config .form-body::-webkit-scrollbar,
-            .app.${MODULE_ID}-scrollable-config .window-content::-webkit-scrollbar {
+            .app.${MODULE_ID}-scrollable-config .tab::-webkit-scrollbar {
                 width: 8px;
             }
             
             .app.drawing-config .sheet-body::-webkit-scrollbar-track,
             .app.drawing-config .form-body::-webkit-scrollbar-track,
-            .app.drawing-config .window-content::-webkit-scrollbar-track,
+            .app.drawing-config .tab::-webkit-scrollbar-track,
             .app.sheet.drawing-config .sheet-body::-webkit-scrollbar-track,
             .app.sheet.drawing-config .form-body::-webkit-scrollbar-track,
-            .app.sheet.drawing-config .window-content::-webkit-scrollbar-track,
+            .app.sheet.drawing-config .tab::-webkit-scrollbar-track,
             .app.${MODULE_ID}-scrollable-config .sheet-body::-webkit-scrollbar-track,
             .app.${MODULE_ID}-scrollable-config .form-body::-webkit-scrollbar-track,
-            .app.${MODULE_ID}-scrollable-config .window-content::-webkit-scrollbar-track {
+            .app.${MODULE_ID}-scrollable-config .tab::-webkit-scrollbar-track {
                 background: var(--color-border-light-tertiary, #ccc);
                 border-radius: 4px;
             }
             
             .app.drawing-config .sheet-body::-webkit-scrollbar-thumb,
             .app.drawing-config .form-body::-webkit-scrollbar-thumb,
-            .app.drawing-config .window-content::-webkit-scrollbar-thumb,
+            .app.drawing-config .tab::-webkit-scrollbar-thumb,
             .app.sheet.drawing-config .sheet-body::-webkit-scrollbar-thumb,
             .app.sheet.drawing-config .form-body::-webkit-scrollbar-thumb,
-            .app.sheet.drawing-config .window-content::-webkit-scrollbar-thumb,
+            .app.sheet.drawing-config .tab::-webkit-scrollbar-thumb,
             .app.${MODULE_ID}-scrollable-config .sheet-body::-webkit-scrollbar-thumb,
             .app.${MODULE_ID}-scrollable-config .form-body::-webkit-scrollbar-thumb,
-            .app.${MODULE_ID}-scrollable-config .window-content::-webkit-scrollbar-thumb {
+            .app.${MODULE_ID}-scrollable-config .tab::-webkit-scrollbar-thumb {
                 background: var(--color-border-dark, #666);
                 border-radius: 4px;
             }
             
             .app.drawing-config .sheet-body::-webkit-scrollbar-thumb:hover,
             .app.drawing-config .form-body::-webkit-scrollbar-thumb:hover,
-            .app.drawing-config .window-content::-webkit-scrollbar-thumb:hover,
+            .app.drawing-config .tab::-webkit-scrollbar-thumb:hover,
             .app.sheet.drawing-config .sheet-body::-webkit-scrollbar-thumb:hover,
             .app.sheet.drawing-config .form-body::-webkit-scrollbar-thumb:hover,
-            .app.sheet.drawing-config .window-content::-webkit-scrollbar-thumb:hover,
+            .app.sheet.drawing-config .tab::-webkit-scrollbar-thumb:hover,
             .app.${MODULE_ID}-scrollable-config .sheet-body::-webkit-scrollbar-thumb:hover,
             .app.${MODULE_ID}-scrollable-config .form-body::-webkit-scrollbar-thumb:hover,
-            .app.${MODULE_ID}-scrollable-config .window-content::-webkit-scrollbar-thumb:hover {
+            .app.${MODULE_ID}-scrollable-config .tab::-webkit-scrollbar-thumb:hover {
                 background: var(--color-border-dark-primary, #333);
             }
             

--- a/scripts/const.js
+++ b/scripts/const.js
@@ -33,5 +33,6 @@ export const DEFAULT_FLAGS = Object.freeze({
     [`flags.${MODULE_ID}.textStyle.lineHeight`]: null,
     [`flags.${MODULE_ID}.textStyle.stroke`]: null,
     [`flags.${MODULE_ID}.textStyle.strokeThickness`]: null,
+    [`flags.${MODULE_ID}.textStyle.strokeOpacity`]: null,
     [`flags.${MODULE_ID}.textStyle.wordWrapWidth`]: "100%"
 });

--- a/scripts/const.js
+++ b/scripts/const.js
@@ -30,6 +30,7 @@ export const DEFAULT_FLAGS = Object.freeze({
     [`flags.${MODULE_ID}.textStyle.fontWeight`]: "normal",
     [`flags.${MODULE_ID}.textStyle.leading`]: 0,
     [`flags.${MODULE_ID}.textStyle.letterSpacing`]: 0,
+    [`flags.${MODULE_ID}.textStyle.lineHeight`]: null,
     [`flags.${MODULE_ID}.textStyle.stroke`]: null,
     [`flags.${MODULE_ID}.textStyle.strokeThickness`]: null,
     [`flags.${MODULE_ID}.textStyle.wordWrapWidth`]: "100%"

--- a/scripts/precise-text.js
+++ b/scripts/precise-text.js
@@ -25,7 +25,8 @@ foundry.canvas.containers.PreciseText.prototype.updateText = function (respectDi
 
     if (!respectDirty || this.dirty || this.localStyleID !== style.styleID) {
         const measured = PIXI.TextMetrics.measureText(this._text || " ", style, style.wordWrap, this.canvas);
-        const size = Math.ceil(Math.max(measured.width, measured.height, 1) + style.padding * 2);
+        const lineHeight = (style.lineHeight === "normal" || style.lineHeight === null) ? style.fontSize * 1.2 : style.lineHeight;
+        const size = Math.ceil(Math.max(measured.width, measured.height, lineHeight ?? 1, 1) + style.padding * 2);
         const maxSize = foundry.canvas.containers.PreciseText._MAX_TEXTURE_SIZE ?? 4096;
         const maxZoom = foundry.canvas.containers.PreciseText._MAX_ZOOM ?? 3;
         const maxResolution = foundry.canvas.containers.PreciseText._MAX_RESOLUTION ?? 2;

--- a/scripts/text.js
+++ b/scripts/text.js
@@ -1,6 +1,7 @@
 import { MODULE_ID } from "./const.js";
 import { WarpedText } from "./warped-text.js";
 import { calculateValue } from "./utils.js";
+import { hexToRgba } from "./utils.js";
 
 Hooks.on("refreshDrawing", drawing => {
     const text = drawing.text;
@@ -38,7 +39,7 @@ Hooks.on("refreshDrawing", drawing => {
         letterSpacing: ts?.letterSpacing ?? 0,
         lineHeight: ts?.lineHeight ?? Math.round((ts?.fontSize ?? document.fontSize ?? 16) * 1.2),
         lineJoin: "round",
-        stroke: ts?.stroke || (Color.from(document.textColor || "#ffffff").hsv[2] > 0.6 ? 0x000000 : 0xFFFFFF),
+        stroke: hexToRgba(ts?.stroke || (Color.from(document.textColor || "#ffffff").hsv[2] > 0.6 ? "#000000" : "#FFFFFF"), ts?.strokeOpacity ?? 1),
         strokeThickness: ts?.strokeThickness ?? Math.max(Math.round(document.fontSize / 32), 2),
         wordWrapWidth: calculateValue(ts?.wordWrapWidth, document.shape.width) ?? document.shape.width
     });

--- a/scripts/text.js
+++ b/scripts/text.js
@@ -36,6 +36,7 @@ Hooks.on("refreshDrawing", drawing => {
         fontWeight: ts?.fontWeight || "normal",
         leading: ts?.leading ?? 0,
         letterSpacing: ts?.letterSpacing ?? 0,
+        lineHeight: ts?.lineHeight ?? Math.round((ts?.fontSize ?? document.fontSize ?? 16) * 1.2),
         lineJoin: "round",
         stroke: ts?.stroke || (Color.from(document.textColor || "#ffffff").hsv[2] > 0.6 ? 0x000000 : 0xFFFFFF),
         strokeThickness: ts?.strokeThickness ?? Math.max(Math.round(document.fontSize / 32), 2),

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -45,6 +45,21 @@ export function calculateValue(value, base) {
     return value;
 }
 
+export function hexToRgba(hex, opacity = 1) {
+    let c = hex.replace(/^#/, "");
+
+    if (c.length === 3) {
+        c = c.split("").map(ch => ch + ch).join("");
+    }
+
+    const num = parseInt(c, 16);
+    const r = (num >> 16) & 255;
+    const g = (num >> 8) & 255;
+    const b = num & 255;
+
+    return `rgba(${r}, ${g}, ${b}, ${opacity})`;
+}
+
 export function stringifyValue(value) {
     value = parseValue(value);
 


### PR DESCRIPTION
- Restored the line-height function
- Added stroke-opacity function (Note: thin stroke thickness may not reflect the full range of opacity due to translation to rgba)
- Updated drop shadow alpha to match the form’s range picker style
- Updated colour picker to match form's colour picker style (fixed bug where interactive colour picker would not apply on update)
- Fix to exclude form tabs and footer ("update drawing" button) from scroll window